### PR TITLE
disabled recursive chown from fsGroup

### DIFF
--- a/flexvolume-driver/cifs
+++ b/flexvolume-driver/cifs
@@ -4,7 +4,7 @@
 DEFAULT_CONTAINER_SECURITY_CONTEXT="context=system_u:object_r:svirt_sandbox_file_t:s0"
 
 init() {
-    echo '{"status": "Success", "capabilities": {"attach": false, "selinuxRelabel": false}}'
+    echo '{"status": "Success", "capabilities": {"attach": false, "selinuxRelabel": false, "fsGroup": false}}'
     exit 0
 }
 


### PR DESCRIPTION
When the cifs share has many files, the volumes timeout because Kubelet tries to chown all of the files. We returns false in the list of capabilities returned from the flex init call. this prevents the recursive chown.
#3 